### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+sudo: required
+dist: xenial
+
+language: generic
+
+install:
+# https://github.com/travis-ci/travis-ci/issues/9080
+- sudo systemctl disable apt-daily.timer
+- sudo killall apt.systemd.daily || true
+
+- sudo apt-add-repository -y ppa:octave/stable
+- sudo apt-get update -qq
+- sudo apt-get install -qq octave liboctave-dev
+- sudo apt-get install -qq ca-certificates make pkg-config git make rsync
+- sudo apt-get install -qq libopenblas-dev coinor-libipopt-dev
+
+script:
+- git clone https://github.com/MATPOWER/matpower.git $TRAVIS_BUILD_DIR/build/matpower
+- rsync -av --progress $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/build/matpower/extras --exclude build
+
+- git clone https://github.com/yalmip/YALMIP.git $TRAVIS_BUILD_DIR/build/yalmip
+- git clone https://github.com/sqlp/sdpt3.git $TRAVIS_BUILD_DIR/build/sdpt3
+- git clone https://github.com/sqlp/sedumi.git $TRAVIS_BUILD_DIR/build/sedumi
+- git clone https://github.com/rwl/ipopt.git $TRAVIS_BUILD_DIR/build/ipopt
+
+# GNU Octave 4.2.2 does not include ismembc function.
+- printf 'function varargout = ismembc(varargin)\n  varargout = cell(nargout, 1);\n  [varargout{:}] = ismember(varargin{:});\nendfunction' >> $TRAVIS_BUILD_DIR/build/matpower/extras/sdp_pf/ismembc.m
+
+- export CFLAGS=-I/usr/include/openblas
+
+- make -C $TRAVIS_BUILD_DIR/build/ipopt
+
+- octave-cli --no-gui --eval "addpath(genpath('$TRAVIS_BUILD_DIR/build/ipopt', '.git'));savepath"
+- octave-cli --no-gui --eval "addpath(genpath('$TRAVIS_BUILD_DIR/build/yalmip', '.git', 'dev'));savepath"
+
+- (cd $TRAVIS_BUILD_DIR/build/sdpt3 && octave-cli --no-gui --eval "install_sdpt3('-rebuild');savepath")
+- (cd $TRAVIS_BUILD_DIR/build/sedumi && octave-cli --no-gui --eval "install_sedumi('-rebuild');savepath")
+
+- cd $TRAVIS_BUILD_DIR/build/matpower
+
+- octave-cli --no-gui --eval ver
+- octave-cli --no-gui --eval "install_matpower(1,1,1)";
+- octave-cli --no-gui --eval path
+- octave-cli --no-gui --eval mpver
+- octave-cli --no-gui --eval "test_mptest(0,1)"
+- octave-cli --no-gui --eval "test_mips(0,1)"
+- octave-cli --no-gui --eval "test_matpower(0,1)"
+- octave-cli --no-gui --eval "test_most(0,1)"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,20 @@ install:
 - sudo apt-add-repository -y ppa:octave/stable
 - sudo apt-get update -qq
 - sudo apt-get install -qq octave liboctave-dev
-- sudo apt-get install -qq ca-certificates make pkg-config git make rsync
+- sudo apt-get install -qq ca-certificates make pkg-config git make
 - sudo apt-get install -qq libopenblas-dev coinor-libipopt-dev
 
 script:
 - git clone https://github.com/MATPOWER/matpower.git $TRAVIS_BUILD_DIR/build/matpower
-- rsync -av --progress $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/build/matpower/extras --exclude build
+
+- mkdir -p $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/maxloadlim $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/misc $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/reduction $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/sdp_pf $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/se $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/smartmarket $TRAVIS_BUILD_DIR/build/matpower/extras
+- cp -a $TRAVIS_BUILD_DIR/state_estimator $TRAVIS_BUILD_DIR/build/matpower/extras
 
 - git clone https://github.com/yalmip/YALMIP.git $TRAVIS_BUILD_DIR/build/yalmip
 - git clone https://github.com/sqlp/sdpt3.git $TRAVIS_BUILD_DIR/build/sdpt3


### PR DESCRIPTION
This adds a Travis CI configuration file. The configuration is based on that submitted here:

https://github.com/MATPOWER/matpower/pull/48

It installs the SDP_PF dependencies along with a MEX interface to IPOPT. Ideally, it would be triggered with each commit to the https://github.com/MATPOWER/matpower repository. However, doing so does not appear to be straightforward.